### PR TITLE
Production jvm docker

### DIFF
--- a/ElvargServer/Dockerfile
+++ b/ElvargServer/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/openjdk:11-jre-slim
+FROM arm64v8/openjdk:17-jdk-slim
 
 COPY ./build/libs/app.jar .
 
@@ -6,6 +6,4 @@ COPY ./data ./data
 
 USER 1000
 
-EXPOSE 49595
-
-CMD ["java","-jar","app.jar", "1"]
+CMD ["java", "-XX:+UseParallelGC","-XX:OnOutOfMemoryError=\"shutdown -r\"", "-Xmx3440M", "-Xmx2048M", "-jar","app.jar", "1"]


### PR DESCRIPTION
* jdk 17 is speed https://javamana.com/2021/09/20210925064330655b.html
* Added max and min memory 
* Added flag so it shuts down when runs out of memory so docker can restart it