### PR TITLE
Autocast fixing & remembering

### DIFF
--- a/ElvargServer/src/main/java/com/elvarg/game/content/combat/CombatFactory.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/content/combat/CombatFactory.java
@@ -111,7 +111,9 @@ public class CombatFactory {
 			p.getCombat().setRangedWeapon(RangedWeapon.getFor(p));
 
 			// Check if player is maging..
-			if (p.getCombat().getCastSpell() != null || p.getCombat().getAutocastSpell() != null) {
+			if (p.getCombat().getCastSpell() != null ||
+					// Ensure player needs staff equipped to use autocast
+					(p.getCombat().getAutocastSpell() != null && p.getEquipment().hasStaffEquipped())) {
 				return MAGIC_COMBAT;
 			}
 

--- a/ElvargServer/src/main/java/com/elvarg/game/content/combat/magic/Autocasting.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/content/combat/magic/Autocasting.java
@@ -28,7 +28,7 @@ public class Autocasting {
     public static final Set<Integer> ANCIENT_SPELL_AUTOCAST_STAFFS = Set.of(KODAI_WAND, MASTER_WAND,
             ANCIENT_STAFF,NIGHTMARE_STAFF,VOLATILE_NIGHTMARE_STAFF,ELDRITCH_NIGHTMARE_STAFF, TOXIC_STAFF_OF_THE_DEAD, ELDER_WAND, STAFF_OF_THE_DEAD, STAFF_OF_LIGHT);
 
-    public static HashMap<Integer, CombatSpells> AUTOCAST_SPELLS = new HashMap<>();
+    public static final HashMap<Integer, CombatSpells> AUTOCAST_SPELLS = new HashMap<>();
 
     static {
         // Modern

--- a/ElvargServer/src/main/java/com/elvarg/game/content/combat/magic/Autocasting.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/content/combat/magic/Autocasting.java
@@ -1,10 +1,129 @@
 package com.elvarg.game.content.combat.magic;
 
+import com.elvarg.game.content.combat.FightType;
+import com.elvarg.game.content.combat.WeaponInterfaces;
 import com.elvarg.game.entity.impl.player.Player;
+import com.elvarg.game.model.MagicSpellbook;
 import com.elvarg.game.model.Skill;
 import com.elvarg.game.model.equipment.BonusManager;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+
+import static com.elvarg.util.ItemIdentifiers.*;
+
 public class Autocasting {
+
+    // Autocast buttons
+    private static final int REGULAR_AUTOCAST_BUTTON = 349;
+    private static final int DEFENSIVE_AUTOCAST_BUTTON = 24111;
+    private static final int CLOSE_REGULAR_AUTOCAST_BUTTON = 2004;
+    private static final int CLOSE_ANCIENT_AUTOCAST_BUTTON = 6161;
+
+    private static final int REGULAR_AUTOCAST_TAB = 1829;
+    private static final int ANCIENT_AUTOCAST_TAB = 1689;
+    private static final int IBANS_AUTOCAST_TAB = 12050;
+
+    public static final Set<Integer> ANCIENT_SPELL_AUTOCAST_STAFFS = Set.of(KODAI_WAND, MASTER_WAND,
+            ANCIENT_STAFF,NIGHTMARE_STAFF,VOLATILE_NIGHTMARE_STAFF,ELDRITCH_NIGHTMARE_STAFF, TOXIC_STAFF_OF_THE_DEAD, ELDER_WAND, STAFF_OF_THE_DEAD, STAFF_OF_LIGHT);
+
+    public static HashMap<Integer, CombatSpells> AUTOCAST_SPELLS = new HashMap<>();
+
+    static {
+        // Modern
+        AUTOCAST_SPELLS.put(1830, CombatSpells.WIND_STRIKE);
+        AUTOCAST_SPELLS.put(1831, CombatSpells.WATER_STRIKE);
+        AUTOCAST_SPELLS.put(1832, CombatSpells.EARTH_STRIKE);
+        AUTOCAST_SPELLS.put(1833, CombatSpells.FIRE_STRIKE);
+        AUTOCAST_SPELLS.put(1834, CombatSpells.WIND_BOLT);
+        AUTOCAST_SPELLS.put(1835, CombatSpells.WATER_BOLT);
+        AUTOCAST_SPELLS.put(1836, CombatSpells.EARTH_BOLT);
+        AUTOCAST_SPELLS.put(1837, CombatSpells.FIRE_BOLT);
+        AUTOCAST_SPELLS.put(1838, CombatSpells.WIND_BLAST);
+        AUTOCAST_SPELLS.put(1839, CombatSpells.WATER_BLAST);
+        AUTOCAST_SPELLS.put(1840, CombatSpells.EARTH_BLAST);
+        AUTOCAST_SPELLS.put(1841, CombatSpells.FIRE_BLAST);
+        AUTOCAST_SPELLS.put(1842, CombatSpells.WIND_WAVE);
+        AUTOCAST_SPELLS.put(1843, CombatSpells.WATER_WAVE);
+        AUTOCAST_SPELLS.put(1844, CombatSpells.EARTH_WAVE);
+        AUTOCAST_SPELLS.put(1845, CombatSpells.FIRE_WAVE);
+
+        // Ancients
+        AUTOCAST_SPELLS.put(13189, CombatSpells.SMOKE_RUSH);
+        AUTOCAST_SPELLS.put(13241, CombatSpells.SHADOW_RUSH);
+        AUTOCAST_SPELLS.put(13247, CombatSpells.BLOOD_RUSH);
+        AUTOCAST_SPELLS.put(6162, CombatSpells.ICE_RUSH);
+        AUTOCAST_SPELLS.put(13215, CombatSpells.SMOKE_BURST);
+        AUTOCAST_SPELLS.put(13267, CombatSpells.SHADOW_BURST);
+        AUTOCAST_SPELLS.put(13167, CombatSpells.BLOOD_BURST);
+        AUTOCAST_SPELLS.put(13125, CombatSpells.ICE_BURST);
+        AUTOCAST_SPELLS.put(13202, CombatSpells.SMOKE_BLITZ);
+        AUTOCAST_SPELLS.put(13254, CombatSpells.SHADOW_BLITZ);
+        AUTOCAST_SPELLS.put(13158, CombatSpells.BLOOD_BLITZ);
+        AUTOCAST_SPELLS.put(13114, CombatSpells.ICE_BLITZ);
+        AUTOCAST_SPELLS.put(13228, CombatSpells.SMOKE_BARRAGE);
+        AUTOCAST_SPELLS.put(13280, CombatSpells.SHADOW_BARRAGE);
+        AUTOCAST_SPELLS.put(13178, CombatSpells.BLOOD_BARRAGE);
+        AUTOCAST_SPELLS.put(13136, CombatSpells.ICE_BARRAGE);
+    }
+
+    public static boolean handleAutocastTab(final Player player, int actionButtonId) {
+        if (AUTOCAST_SPELLS.containsKey(actionButtonId)) {
+            setAutocast(player, AUTOCAST_SPELLS.get(actionButtonId).getSpell());
+            WeaponInterfaces.assign(player);
+            return true;
+        }
+
+        switch(actionButtonId) {
+            case CLOSE_REGULAR_AUTOCAST_BUTTON:
+            case CLOSE_ANCIENT_AUTOCAST_BUTTON:
+                setAutocast(player, null); // When clicking cancel, remove autocast?
+                player.getPacketSender().sendTabInterface(0, player.getWeapon().getInterfaceId());
+                return true;
+        }
+
+        return false;
+    }
+
+    public static boolean handleWeaponInterface(final Player player, int actionButtonId) {
+        if (actionButtonId != REGULAR_AUTOCAST_BUTTON && actionButtonId != DEFENSIVE_AUTOCAST_BUTTON) {
+            return false;
+        }
+
+        if (player.getSpellbook() == MagicSpellbook.LUNAR) {
+            player.getPacketSender().sendMessage("You can't autocast lunar spells.");
+            return true;
+        }
+
+        if (!player.getEquipment().hasStaffEquipped()) {
+            return true;
+        }
+
+        switch (player.getSpellbook()) {
+            case ANCIENT -> {
+                if (!ANCIENT_SPELL_AUTOCAST_STAFFS.contains(player.getEquipment().getWeapon().getId()) && player.getEquipment().getWeapon().getId() != AHRIMS_STAFF) {
+                    // Ensure this is a staff capable of casting ancients. Ahrims staff can cast both regular and ancients.
+                    player.getPacketSender().sendMessage("You can only autocast regular offensive spells with this staff.");
+                    return true;
+                }
+
+                player.getPacketSender().sendTabInterface(0, ANCIENT_AUTOCAST_TAB);
+            }
+
+            case NORMAL -> {
+                if (player.getEquipment().getWeapon().getId() == ANCIENT_STAFF) {
+                    player.getPacketSender().sendMessage("You can only autocast ancient magicks with that.");
+                    return true;
+                }
+
+                player.getPacketSender().sendTabInterface(0, REGULAR_AUTOCAST_TAB);
+            }
+        }
+
+        player.getPacketSender().sendMessage("You can set a default autocast spell any time from the magic tab.");
+        return true;
+    }
 
     public static boolean toggleAutocast(final Player player, int actionButtonId) {
         CombatSpell cbSpell = CombatSpells.getCombatSpell(actionButtonId);
@@ -29,17 +148,40 @@ public class Autocasting {
             setAutocast(player, cbSpell);
 
         }
+
         return true;
     }
 
     public static void setAutocast(Player player, CombatSpell spell) {
+        // First, set the Player's preferred autocast spell
+        player.getCombat().setAutocastSpell(spell);
+
+        if (!player.getEquipment().hasStaffEquipped() && spell != null) {
+            player.getPacketSender().sendMessage("Default spell set. Please equip a staff to use autocast.");
+            return;
+        }
+
         if (spell == null) {
             player.getPacketSender().sendAutocastId(-1).sendConfig(108, 3);
         } else {
             player.getPacketSender().sendAutocastId(spell.spellId()).sendConfig(108, 1);
         }
-        player.getCombat().setAutocastSpell(spell);
 
         BonusManager.update(player);
+        updateConfigsOnAutocast(player, spell != null);
+    }
+
+    private static final List<FightType> STAFF_FIGHT_TYPES = List.of(
+            FightType.STAFF_BASH,
+            FightType.STAFF_FOCUS,
+            FightType.STAFF_POUND
+    );
+
+    private static void updateConfigsOnAutocast(final Player player, boolean autocast) {
+        if (autocast) {
+            for (final FightType type : STAFF_FIGHT_TYPES) {
+                player.getPacketSender().sendConfig(type.getParentId(), 3);
+            }
+        }
     }
 }

--- a/ElvargServer/src/main/java/com/elvarg/game/model/container/ItemContainer.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/model/container/ItemContainer.java
@@ -862,4 +862,13 @@ public abstract class ItemContainer {
 
         return Long.toString(value);
     }
+
+    public boolean hasAt(int slot, int item) {
+        Item at = items[slot];
+        return at != null && at.getId() == item;
+    }
+
+    public boolean hasAt(int slot) {
+        return slot >= 0 & slot < items.length && items[slot] != null;
+    }
 }

--- a/ElvargServer/src/main/java/com/elvarg/game/model/container/impl/Equipment.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/model/container/impl/Equipment.java
@@ -1,5 +1,6 @@
 package com.elvarg.game.model.container.impl;
 
+import com.elvarg.game.content.combat.WeaponInterfaces;
 import com.elvarg.game.definition.ItemDefinition;
 import com.elvarg.game.entity.impl.player.Player;
 import com.elvarg.game.model.Item;
@@ -145,5 +146,15 @@ public class Equipment extends ItemContainer {
                 count++;
         }
         return count >= 3;
+    }
+
+    public boolean hasStaffEquipped() {
+        Item staff = get(Equipment.WEAPON_SLOT);
+        return (staff != null && (getPlayer().getWeapon() == WeaponInterfaces.WeaponInterface.STAFF
+                || getPlayer().getWeapon() == WeaponInterfaces.WeaponInterface.ANCIENT_STAFF));
+    }
+
+    public Item getWeapon() {
+        return get(Equipment.WEAPON_SLOT);
     }
 }

--- a/ElvargServer/src/main/java/com/elvarg/net/packet/impl/ButtonClickPacketListener.java
+++ b/ElvargServer/src/main/java/com/elvarg/net/packet/impl/ButtonClickPacketListener.java
@@ -60,10 +60,7 @@ public class ButtonClickPacketListener implements PacketExecutor {
 	private static final int PRICE_CHECKER_DEPOSIT_ALL = 18252;
 	private static final int TOGGLE_EXP_LOCK = 476;
 	private static final int OPEN_WORLD_MAP = 156;
-	
-	// Autocast buttons
-	private static final int AUTOCAST_BUTTON_1 = 349;
-	private static final int AUTOCAST_BUTTON_2 = 24111;
+
 	// Trade buttons
 	private static final int TRADE_ACCEPT_BUTTON_1 = 3420;
 	private static final int TRADE_ACCEPT_BUTTON_2 = 3546;
@@ -83,7 +80,9 @@ public class ButtonClickPacketListener implements PacketExecutor {
 		if (PrayerHandler.togglePrayer(player, button)) {
 			return true;
 		}
-		if (Autocasting.toggleAutocast(player, button)) {
+		if (Autocasting.handleWeaponInterface(player, button)
+				|| Autocasting.handleAutocastTab(player, button)
+				|| Autocasting.toggleAutocast(player, button)) {
 			return true;
 		}
 		if (WeaponInterfaces.changeCombatSettings(player, button)) {
@@ -247,13 +246,6 @@ public class ButtonClickPacketListener implements PacketExecutor {
 
 		case CANCEL_DESTROY_ITEM:
 			player.getPacketSender().sendInterfaceRemoval();
-			break;
-
-		case AUTOCAST_BUTTON_1:
-		case AUTOCAST_BUTTON_2:
-			player.getPacketSender()
-					.sendMessage("A spell can be autocast by simply right-clicking on it in your Magic spellbook and ")
-					.sendMessage("selecting the \"Autocast\" option.");
 			break;
 
 		case TOGGLE_EXP_LOCK:

--- a/ElvargServer/src/main/java/com/elvarg/net/packet/impl/EquipPacketListener.java
+++ b/ElvargServer/src/main/java/com/elvarg/net/packet/impl/EquipPacketListener.java
@@ -33,10 +33,6 @@ public class EquipPacketListener implements PacketExecutor {
 		}
 		player.getPacketSender().sendSpecialAttackState(false);
 		WeaponInterfaces.assign(player);
-		if (player.getCombat().getAutocastSpell() != null) {
-			Autocasting.setAutocast(player, null);
-			player.getPacketSender().sendMessage("Autocast spell cleared.");
-		}
 	}
 
 	@Override


### PR DESCRIPTION
So on Elvarg, by default the autocast buttons on staff weapon interfaces are disabled. Players can autocast any spell at any time from the magic tab directly. The downside of this is the spell gets deactivated when a new weapon is equipped. This is frustrating and makes switching/bridding very painful.

Expected behaviour:
-Player should be able to select autocast spells from the buttons on the weapon interface, when a staff is equipped
-Player shouldn't be able to autocast without having a staff equipped
-Autocast spell should be remembered if player switches to e.g. magic short bow then back to their staff

I spent a few hours before work fixing it this morning.