### PR TITLE
Attribute system for Mobile entities

### DIFF
--- a/ElvargServer/src/main/java/com/elvarg/game/entity/attributes/AttributeKey.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/entity/attributes/AttributeKey.java
@@ -1,0 +1,29 @@
+package com.elvarg.game.entity.attributes;
+
+public enum AttributeKey {
+
+    DEFENSIVE_AUTOCAST("defensive_autocast", AttributeType.BOOLEAN),
+
+    AUTOCAST_SELECTED("autocast_selected", AttributeType.BOOLEAN);
+
+    private String saveName;
+    private AttributeType type;
+
+    AttributeKey() {
+
+    }
+
+    AttributeKey(String name, AttributeType persistType) {
+        this.saveName = name;
+        this.type = persistType;
+    }
+
+    public String saveName() {
+        return saveName;
+    }
+
+    public AttributeType saveType() {
+        return type;
+    }
+
+}

--- a/ElvargServer/src/main/java/com/elvarg/game/entity/attributes/AttributeType.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/entity/attributes/AttributeType.java
@@ -1,0 +1,5 @@
+package com.elvarg.game.entity.attributes;
+
+public enum AttributeType {
+    INTEGER, STRING, DOUBLE, LONG, BOOLEAN, ARRAY, STRING_STRING_MAP
+}

--- a/ElvargServer/src/main/java/com/elvarg/game/entity/impl/Mobile.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/entity/impl/Mobile.java
@@ -7,6 +7,7 @@ import com.elvarg.game.content.combat.CombatType;
 import com.elvarg.game.content.combat.hit.HitDamage;
 import com.elvarg.game.content.combat.hit.PendingHit;
 import com.elvarg.game.entity.Entity;
+import com.elvarg.game.entity.attributes.AttributeKey;
 import com.elvarg.game.entity.impl.npc.NPC;
 import com.elvarg.game.entity.impl.player.Player;
 import com.elvarg.game.entity.impl.playerbot.PlayerBot;
@@ -21,6 +22,9 @@ import com.elvarg.game.task.Task;
 import com.elvarg.game.task.TaskManager;
 import com.elvarg.util.Stopwatch;
 import com.elvarg.util.timers.TimerRepository;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Represents a {@link Player} or {@link NPC}.
@@ -58,10 +62,16 @@ public abstract class Mobile extends Entity {
 	private boolean isTeleporting = false;
 	private HitDamage primaryHit;
 	private HitDamage secondaryHit;
+
 	/**
 	 * Is this entity registered.
 	 */
 	private boolean registered;
+
+	/**
+	 * Attributes related to this Mobile which can be saved / loaded
+	 */
+	protected Map<AttributeKey, Object> attributes;
 
 	/**
 	 * Constructs this character/entity
@@ -596,4 +606,51 @@ public abstract class Mobile extends Entity {
         }
         return ((NPC) this);
     }
+
+	/**
+	 * Gets an attribute without a default value.
+	 * Make sure to be careful using this, to avoid
+	 * NullPointerExceptions because of no default value.
+	 *
+	 * @param key
+	 * @param <T>
+	 * @return
+	 */
+	@SuppressWarnings("unchecked")
+	public <T> T getAttrib(AttributeKey key) {
+		return attributes == null ? null : (T) attributes.get(key);
+	}
+
+	/**
+	 * Gets an attribute with a default value.
+	 *
+	 * @param key
+	 * @param defaultValue
+	 * @param <T>
+	 * @return
+	 */
+	@SuppressWarnings("unchecked")
+	public <T> T getAttributeOr(AttributeKey key, Object defaultValue) {
+		return attributes == null ? (T) defaultValue : (T) attributes.getOrDefault(key, defaultValue);
+	}
+
+	@SuppressWarnings("unchecked")
+	public <T> T getOrT(AttributeKey key, T defaultValue) {
+		return attributes == null ? (T) defaultValue : (T) attributes.getOrDefault(key, defaultValue);
+	}
+
+	public void clearAttributes(AttributeKey key) {
+		if (attributes != null)
+			attributes.remove(key);
+	}
+
+	public void clearAttributes() {
+		attributes.clear();
+	}
+
+	public Object putAttribute(AttributeKey key, Object v) {
+		if (attributes == null)
+			attributes = new HashMap<>();
+		return attributes.put(key, v);
+	}
 }


### PR DESCRIPTION
This basically allows us to do:

`player.<Boolean>getAttributeOr(AttributeKey.DEFENSIVE_AUTOCAST,false)`

or 

`player.putAttribute(AttributeKey.AUTOCAST_SELECTED,true);`

This is great for stuff that doesn't need to be cluttering the Mobile's class all the time. E.g. timers, poison effects, which autocast you have selected etc.

In future AttributeKey could have a boolean property for 'persists' - this would dictate which attributes got persisted (for player states)