### PR TITLE
[Discord OAuth] Client-side changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+out/

--- a/ElvargClient/build.gradle.kts
+++ b/ElvargClient/build.gradle.kts
@@ -14,6 +14,10 @@ repositories {
     }
 }
 
+dependencies {
+    implementation("org.nanohttpd:nanohttpd:2.3.1")
+}
+
 group = "Elvarg"
 version = "1.0-SNAPSHOT"
 description = "Elvarg-Game-Client"

--- a/ElvargClient/gradle/wrapper/gradle-wrapper.properties
+++ b/ElvargClient/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ElvargClient/src/main/java/app/rsps/DiscordOAuth.java
+++ b/ElvargClient/src/main/java/app/rsps/DiscordOAuth.java
@@ -1,0 +1,84 @@
+package app.rsps;
+
+/**
+ * Basic singleton web server that listens on localhost:8080.
+ *
+ * @author shogun <shogunrsps@gmail.com>
+ */
+
+import fi.iki.elonen.NanoHTTPD;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+public class DiscordOAuth {
+
+    private static DiscordOAuth instance;
+
+    private DiscordOAuthListener httpd;
+    private Thread runner;
+    private Function<String, Void> callback;
+
+    public static DiscordOAuth getInstance() {
+        return instance;
+    }
+
+    public static String getOAuthUrl() {
+        return "https://discord.com/api/oauth2/authorize?client_id=1010001099815669811&redirect_uri=http%3A%2F%2Flocalhost%3A8080&response_type=code&scope=identify";
+    }
+
+    /**
+     * Lightweight wrapper around the web framework. Intended to isolate the actual HTTP
+     * processing of receiving the Discord callback
+     */
+    class DiscordOAuthListener extends NanoHTTPD {
+        private DiscordOAuth parent;
+        public DiscordOAuthListener(DiscordOAuth parent) {
+            super(8080);
+            this.parent = parent;
+        }
+
+        @Override
+        public Response serve(IHTTPSession session) {
+            if (parent.callback == null) return null;
+
+            String msg = "<html><head><meta http-equiv=\"refresh\" content=\"0; URL=https://oldschool.runescape.com\" /></head></html>";
+
+            Map<String, List<String>> params = session.getParameters();
+            if (params.containsKey("code")) {
+                String code = params.get("code").get(0);
+                this.parent.callback(code);
+            }
+
+            return NanoHTTPD.newFixedLengthResponse(msg);
+        }
+    }
+
+    public DiscordOAuth() {
+        httpd = new DiscordOAuthListener(this);
+
+        runner = new Thread(() -> {
+            try {
+                httpd.start(NanoHTTPD.SOCKET_READ_TIMEOUT, false);
+            } catch (IOException ioe) {
+                System.exit(-1);
+            }
+        });
+        runner.start();
+    }
+
+    public void setCallback(Function<String, Void> callback) {
+        this.callback = callback;
+    }
+
+    public void callback(String token) {
+        this.callback.apply(token);
+        this.callback = null;
+    }
+
+    static {
+        instance = new DiscordOAuth();
+    }
+}

--- a/ElvargClient/src/main/java/com/runescape/Client.java
+++ b/ElvargClient/src/main/java/com/runescape/Client.java
@@ -1,5 +1,6 @@
 package com.runescape;
 
+import app.rsps.DiscordOAuth;
 import com.runescape.cache.FileArchive;
 import com.runescape.cache.FileStore;
 import com.runescape.cache.Resource;
@@ -13,18 +14,6 @@ import com.runescape.cache.def.FloorDefinition;
 import com.runescape.cache.def.ItemDefinition;
 import com.runescape.cache.def.NpcDefinition;
 import com.runescape.cache.def.ObjectDefinition;
-import com.runescape.graphics.DropdownMenu;
-import com.runescape.graphics.GameFont;
-import com.runescape.graphics.IndexedImage;
-import com.runescape.graphics.RSFont;
-import com.runescape.graphics.Slider;
-import com.runescape.graphics.sprite.Sprite;
-import com.runescape.graphics.sprite.SpriteCache;
-import com.runescape.graphics.widget.Bank;
-import com.runescape.graphics.widget.Bank.BankTabShow;
-import com.runescape.graphics.widget.OSRSCreationMenu;
-import com.runescape.graphics.widget.SettingsWidget;
-import com.runescape.graphics.widget.Widget;
 import com.runescape.collection.Deque;
 import com.runescape.collection.Linkable;
 import com.runescape.draw.Console;
@@ -33,14 +22,17 @@ import com.runescape.draw.Rasterizer2D;
 import com.runescape.draw.Rasterizer3D;
 import com.runescape.draw.skillorbs.SkillOrbs;
 import com.runescape.draw.teleports.TeleportChatBox;
-import com.runescape.entity.GameObject;
-import com.runescape.entity.Item;
-import com.runescape.entity.Mob;
-import com.runescape.entity.Npc;
-import com.runescape.entity.Player;
-import com.runescape.entity.Renderable;
+import com.runescape.entity.*;
 import com.runescape.entity.model.IdentityKit;
 import com.runescape.entity.model.Model;
+import com.runescape.graphics.*;
+import com.runescape.graphics.sprite.Sprite;
+import com.runescape.graphics.sprite.SpriteCache;
+import com.runescape.graphics.widget.Bank;
+import com.runescape.graphics.widget.Bank.BankTabShow;
+import com.runescape.graphics.widget.OSRSCreationMenu;
+import com.runescape.graphics.widget.SettingsWidget;
+import com.runescape.graphics.widget.Widget;
 import com.runescape.io.Buffer;
 import com.runescape.io.PacketConstants;
 import com.runescape.io.PacketSender;
@@ -50,12 +42,7 @@ import com.runescape.model.EffectTimer;
 import com.runescape.model.content.Keybinding;
 import com.runescape.net.BufferedConnection;
 import com.runescape.net.IsaacCipher;
-import com.runescape.scene.AnimableObject;
-import com.runescape.scene.CollisionMap;
-import com.runescape.scene.MapRegion;
-import com.runescape.scene.Projectile;
-import com.runescape.scene.SceneGraph;
-import com.runescape.scene.SceneObject;
+import com.runescape.scene.*;
 import com.runescape.scene.object.GroundDecoration;
 import com.runescape.scene.object.SpawnedObject;
 import com.runescape.scene.object.WallDecoration;
@@ -64,33 +51,14 @@ import com.runescape.sign.SignLink;
 import com.runescape.sound.SoundConstants;
 import com.runescape.sound.SoundPlayer;
 import com.runescape.sound.Track;
-import com.runescape.util.ChatMessageCodec;
-import com.runescape.util.MessageCensor;
-import com.runescape.util.MiscUtils;
-import com.runescape.util.MouseDetection;
-import com.runescape.util.SecondsTimer;
-import com.runescape.util.SkillConstants;
-import com.runescape.util.StringUtils;
+import com.runescape.util.*;
 
 import javax.imageio.ImageIO;
 import java.applet.AppletContext;
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Font;
-import java.awt.Graphics;
-import java.awt.Graphics2D;
-import java.awt.Image;
-import java.awt.Toolkit;
+import java.awt.*;
 import java.awt.event.KeyEvent;
 import java.awt.image.BufferedImage;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import java.io.*;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.URL;
@@ -730,10 +698,12 @@ public class Client extends GameApplet {
     private long last;
     private int configPercentage;
 
+    private String discordCode;
+
     public Client() {
         expectedCRCs = new int[9];
-    	packetSender = new PacketSender(null);
-    	chatBuffer = new Buffer(new byte[5000]);
+        packetSender = new PacketSender(null);
+        chatBuffer = new Buffer(new byte[5000]);
         fullscreenInterfaceID = -1;
         soundVolume = new int[50];
         chatTypeView = 0;
@@ -8814,7 +8784,6 @@ public class Client extends GameApplet {
         if (chatboxImageProducer != null) {
             return;
         }
-
         nullLoader();
         super.fullGameScreen = null;
         topLeft1BackgroundTile = null;
@@ -13202,10 +13171,16 @@ public class Client extends GameApplet {
             int l = c / 2 - 80;
             int k1 = c1 / 2 + 20;
             titleButtonIndexedImage.draw(l - 73, k1 - 20);
-            boldText.method382(0xffffff, l, "New User", k1 + 5, true);
+            boldText.method382(0xffffff, l, "Discord Login", k1 + 5, true);
             l = c / 2 + 80;
             titleButtonIndexedImage.draw(l - 73, k1 - 20);
             boldText.method382(0xffffff, l, "Existing User", k1 + 5, true);
+        }
+        if (loginScreenState == 1) {
+            int i = c1 / 2 - 20;
+            boldText.method382(0xff0000, c / 2, "Discord Integration", i, true);
+            i += 30;
+            boldText.method382(0xffffff, c / 2, "Waiting for OAuth...", i, true);
         }
         if (loginScreenState == 2) {
             int j = c1 / 2 - 45;
@@ -13636,6 +13611,10 @@ public class Client extends GameApplet {
 
     }
 
+    private void discordLogin(String code) {
+        discordCode = code;
+    }
+
     private void processLoginScreenInput() {
         if (loading)
             return;
@@ -13644,8 +13623,6 @@ public class Client extends GameApplet {
                 Configuration.enableMusic = !Configuration.enableMusic;
             }
 
-            int i = super.myWidth / 2;
-            int l = super.myHeight / 2;
             if (super.clickMode3 == 1) {
                 if (mouseInRegion(394, 530, 275, 307)) {
                     firstLoginMessage = "";
@@ -13655,11 +13632,22 @@ public class Client extends GameApplet {
                         loginScreenCursorPos = 0;
                     }
                 } else if (mouseInRegion(229, 375, 271, 312)) {
-                    MiscUtils.launchURL("www.aqp.io");
+                    DiscordOAuth.getInstance().setCallback((s) -> {
+                        discordLogin(s);
+                        return null;
+                    });
+
+                    MiscUtils.launchURL(DiscordOAuth.getOAuthUrl());
+                    loginScreenState = 1;
                 }
             }
+        } else if (loginScreenState == 1) {
+            if (discordCode != null) {
+                discordCode = null;
+                login("admin", "admin", false);
+                return;
+            }
         } else if (loginScreenState == 2) {
-
             if (super.clickMode3 == 1) {
                 if (super.saveClickX >= 722 && super.saveClickX <= 753 && super.saveClickY >= 463 && super.saveClickY <= 493) {
                     Configuration.enableMusic = !Configuration.enableMusic;

--- a/ElvargClient/src/main/java/com/runescape/util/MiscUtils.java
+++ b/ElvargClient/src/main/java/com/runescape/util/MiscUtils.java
@@ -8,10 +8,7 @@ public final class MiscUtils {
         String osName = System.getProperty("os.name");
         try {
             if (osName.startsWith("Mac OS")) {
-                Class<?> fileMgr = Class.forName("com.apple.eio.FileManager");
-                Method openURL = fileMgr.getDeclaredMethod("openURL",
-                        String.class);
-                openURL.invoke(null, url);
+                Runtime.getRuntime().exec("open " + url);
             } else if (osName.startsWith("Windows"))
                 Runtime.getRuntime().exec("rundll32 url.dll,FileProtocolHandler " + url);
             else {


### PR DESCRIPTION
Part 1 of client-side changes:
- NanoHTTPD added as a client-hosted interceptor for OAuth2 code
- New User button renamed to `Discord Login`
- Code forwarding and dummy login as admin/admin

Remaining big chunks:
- Code exchange for token
- Identity verification
- Server-side storage for Discord snowflake <-> ingame player