### PR TITLE
Moving discord logic out of PlayerPersistence

### DIFF
--- a/ElvargClient/src/main/java/com/runescape/Client.java
+++ b/ElvargClient/src/main/java/com/runescape/Client.java
@@ -13652,7 +13652,10 @@ public class Client extends GameApplet {
                     canUseCachedToken = true;
                     loginScreenState = 1;
 
-                    if (discordToken != "") return;
+                    if (discordToken.length() > 0) {
+                        // We already have a Discord token available
+                        return;
+                    }
 
                     DiscordOAuth.getInstance().setCallback((code) -> {
                         discordCode = code;
@@ -13670,7 +13673,7 @@ public class Client extends GameApplet {
                 login("authz_code", discordCode, false, true);
                 discordCode = null;
                 return;
-            } else if (discordToken != "" && canUseCachedToken) {
+            } else if (discordToken.length() > 0 && canUseCachedToken) {
                 login("cached_token", discordToken, false, true);
                 canUseCachedToken = false;
 

--- a/ElvargServer/src/main/java/com/elvarg/game/entity/impl/player/persistence/PlayerPersistence.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/entity/impl/player/persistence/PlayerPersistence.java
@@ -18,10 +18,8 @@ public abstract class PlayerPersistence {
         return PasswordUtil.generatePasswordHashWithSalt(plainPassword);
     }
 
-    public boolean checkPassword(LoginDetailsMessage msg, PlayerSave playerSave) {
-        if (msg.isDiscord() != playerSave.isDiscordLogin()) return false;
-
+    public boolean checkPassword(String password, PlayerSave playerSave) {
         String passwordHashWithSalt = playerSave.getPasswordHashWithSalt();
-        return PasswordUtil.passwordsMatch(msg.getPassword(), passwordHashWithSalt);
+        return PasswordUtil.passwordsMatch(password, passwordHashWithSalt);
     }
 }

--- a/ElvargServer/src/main/java/com/elvarg/game/entity/impl/player/persistence/jsonfile/JSONFilePlayerPersistence.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/entity/impl/player/persistence/jsonfile/JSONFilePlayerPersistence.java
@@ -68,6 +68,7 @@ public class JSONFilePlayerPersistence extends PlayerPersistence {
         return plainPassword;
     }
 
+    @Override
     public boolean checkPassword(String plainPassword, PlayerSave playerSave) {
         // TODO: Fix password encryption for JSON
         return plainPassword.equals(playerSave.getPasswordHashWithSalt());


### PR DESCRIPTION
During implementation of Discord login, the ability to override `checkPassword()` was lost, so JSON saving/loading was temporarily broken. This moves the discord logic out of checkPassword and re-implements the override for JSON file player persistence.

Also Discord login was broken completely because Shogun was comparing `discordToken != ""` which would be true even before the discord token was returned from the server. (Empty byte array != empty string). Switched to using `discordToken.length >0`