### PR TITLE
Fixing wonky display switching

### DIFF
--- a/ElvargClient/src/main/java/com/runescape/Client.java
+++ b/ElvargClient/src/main/java/com/runescape/Client.java
@@ -163,7 +163,21 @@ public class Client extends GameApplet {
     private static final String validUserPassChars =
             "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!\"\243$%^&*()-_=+[{]};:'@#~,<.>/?\\| ";
     public static final SpriteCache spriteCache = new SpriteCache();
-    public static ScreenMode frameMode = ScreenMode.FIXED;
+    public static ScreenMode frameMode = ScreenMode.RESIZABLE;
+
+    /**
+     * Utility function to get the current dimensions of the client frame.
+     *
+     * @return Dimension - The current dimensions of the client frame.
+     */
+    public static Dimension frameDimension() {
+        if (frameMode == ScreenMode.RESIZABLE) {
+            return new Dimension(766, 529);
+        }
+
+        return new Dimension(765, 503);
+    }
+
     public static int frameWidth = 765;
     public static int frameHeight = 503;
     public static int screenAreaWidth = 512;
@@ -853,27 +867,26 @@ public class Client extends GameApplet {
     }
 
     public void frameMode(ScreenMode screenMode) {
-        if (frameMode != screenMode) {
-            frameMode = screenMode;
-            if (screenMode == ScreenMode.FIXED) {
-                frameWidth = 765;
-                frameHeight = 503;
-                cameraZoom = 600;
-                SceneGraph.viewDistance = 9;
-            } else if (screenMode == ScreenMode.RESIZABLE) {
-                frameWidth = 766;
-                frameHeight = 529;
-                cameraZoom = 850;
-                SceneGraph.viewDistance = 10;
-            } else if (screenMode == ScreenMode.FULLSCREEN) {
-                cameraZoom = 600;
-                SceneGraph.viewDistance = 10;
-                frameWidth = (int) Toolkit.getDefaultToolkit().getScreenSize().getWidth();
-                frameHeight = (int) Toolkit.getDefaultToolkit().getScreenSize().getHeight();
-            }
-            rebuildFrameSize(screenMode, frameWidth, frameHeight);
-            setBounds();
+        frameMode = screenMode;
+        if (screenMode == ScreenMode.FIXED) {
+            frameWidth = 765;
+            frameHeight = 503;
+            cameraZoom = 600;
+            SceneGraph.viewDistance = 9;
+        } else if (screenMode == ScreenMode.RESIZABLE) {
+            frameWidth = 766;
+            frameHeight = 529;
+            cameraZoom = 850;
+            SceneGraph.viewDistance = 10;
+        } else if (screenMode == ScreenMode.FULLSCREEN) {
+            cameraZoom = 600;
+            SceneGraph.viewDistance = 10;
+            frameWidth = (int) Toolkit.getDefaultToolkit().getScreenSize().getWidth();
+            frameHeight = (int) Toolkit.getDefaultToolkit().getScreenSize().getHeight();
         }
+        rebuildFrameSize(screenMode, frameWidth, frameHeight);
+        setBounds();
+
         stackSideStones = screenMode != ScreenMode.FIXED && stackSideStones;
         showChatComponents = screenMode == ScreenMode.FIXED || showChatComponents;
         showTabComponents = screenMode == ScreenMode.FIXED || showTabComponents;
@@ -884,7 +897,7 @@ public class Client extends GameApplet {
         screenAreaHeight = (screenMode == ScreenMode.FIXED) ? 334 : height;
         frameWidth = width;
         frameHeight = height;
-        instance.rebuildFrame(width, height, screenMode == ScreenMode.RESIZABLE, screenMode == ScreenMode.FULLSCREEN);
+        this.rebuildFrame(width, height, screenMode == ScreenMode.RESIZABLE, screenMode == ScreenMode.FULLSCREEN);
     }
 
     private static void setBounds() {
@@ -1053,9 +1066,10 @@ public class Client extends GameApplet {
             if (SignLink.mainapp == null) {
                 SignLink.init(this);
             }
-            frameMode(ScreenMode.FIXED);
+            // Don't call frame mode if we're running as desktop client, this can cause an extra window to appear
+            //frameMode(ScreenMode.RESIZABLE);
             instance = this;
-            initClientFrame(503, 765);
+            initClientFrame(frameMode == ScreenMode.FIXED ? 503 : 529, frameMode == ScreenMode.FIXED ? 765 : 766);
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -4227,7 +4241,7 @@ public class Client extends GameApplet {
         currentSong = -1;
         nextSong = -1;
         prevSong = 0;
-        frameMode(ScreenMode.FIXED);
+        frameMode(frameMode);
         savePlayerData();
     }
 
@@ -9248,7 +9262,7 @@ public class Client extends GameApplet {
                 SettingsWidget.updateSettings();
                 this.stopMidi();
                 setupGameplayScreen();
-                frameMode(ScreenMode.FIXED);
+                frameMode(frameMode);
                 return;
             }
             if (response == 28) {

--- a/ElvargClient/src/main/java/com/runescape/Client.java
+++ b/ElvargClient/src/main/java/com/runescape/Client.java
@@ -173,7 +173,6 @@ public class Client extends GameApplet {
     public static Dimension frameDimension() {
         if (frameMode == ScreenMode.RESIZABLE) {
             return new Dimension(800, 600);
-            //return new Dimension(766, 529);
         }
 
         return new Dimension(765, 503);

--- a/ElvargClient/src/main/java/com/runescape/Client.java
+++ b/ElvargClient/src/main/java/com/runescape/Client.java
@@ -172,7 +172,8 @@ public class Client extends GameApplet {
      */
     public static Dimension frameDimension() {
         if (frameMode == ScreenMode.RESIZABLE) {
-            return new Dimension(766, 529);
+            return new Dimension(800, 600);
+            //return new Dimension(766, 529);
         }
 
         return new Dimension(765, 503);
@@ -868,14 +869,12 @@ public class Client extends GameApplet {
 
     public void frameMode(ScreenMode screenMode) {
         frameMode = screenMode;
+        frameWidth = frameDimension().width;
+        frameHeight = frameDimension().height;
         if (screenMode == ScreenMode.FIXED) {
-            frameWidth = 765;
-            frameHeight = 503;
             cameraZoom = 600;
             SceneGraph.viewDistance = 9;
         } else if (screenMode == ScreenMode.RESIZABLE) {
-            frameWidth = 766;
-            frameHeight = 529;
             cameraZoom = 850;
             SceneGraph.viewDistance = 10;
         } else if (screenMode == ScreenMode.FULLSCREEN) {
@@ -1066,10 +1065,8 @@ public class Client extends GameApplet {
             if (SignLink.mainapp == null) {
                 SignLink.init(this);
             }
-            // Don't call frame mode if we're running as desktop client, this can cause an extra window to appear
-            //frameMode(ScreenMode.RESIZABLE);
             instance = this;
-            initClientFrame(frameMode == ScreenMode.FIXED ? 503 : 529, frameMode == ScreenMode.FIXED ? 765 : 766);
+            initClientFrame(frameDimension().width, frameDimension().height);
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -10117,7 +10114,7 @@ public class Client extends GameApplet {
     private void showErrorScreen() {
         Graphics g = getGameComponent().getGraphics();
         g.setColor(Color.black);
-        g.fillRect(0, 0, 765, 503);
+        g.fillRect(0, 0, frameDimension().width, frameDimension().height);
         method4(1);
         if (loadingError) {
             aBoolean831 = false;
@@ -10301,8 +10298,8 @@ public class Client extends GameApplet {
                     Widget rsInterface_1 = Widget.interfaceCache[openInterfaceId];
                     if (rsInterface_1.width == 512 && rsInterface_1.height == 334
                             && rsInterface_1.type == 0) {
-                        rsInterface_1.width = 765;
-                        rsInterface_1.height = 503;
+                        rsInterface_1.width = frameDimension().width;
+                        rsInterface_1.height = frameDimension().height;
                     }
                     try {
                         drawInterface(0, 0, rsInterface_1, 8);
@@ -10313,8 +10310,8 @@ public class Client extends GameApplet {
                 Widget rsInterface = Widget.interfaceCache[fullscreenInterfaceID];
                 if (rsInterface.width == 512 && rsInterface.height == 334
                         && rsInterface.type == 0) {
-                    rsInterface.width = 765;
-                    rsInterface.height = 503;
+                    rsInterface.width = frameDimension().width;
+                    rsInterface.height = frameDimension().height;
                 }
                 try {
                     drawInterface(0, 0, rsInterface, 8);
@@ -15705,7 +15702,7 @@ public class Client extends GameApplet {
         loginMusicImageProducer = null;
         middleLeft1BackgroundTile = null;
         aRSImageProducer_1115 = null;
-        super.fullGameScreen = new ProducingGraphicsBuffer(765, 503);
+        super.fullGameScreen = new ProducingGraphicsBuffer(frameDimension().width, frameDimension().height);
         welcomeScreenRaised = true;
     }
 

--- a/ElvargClient/src/main/java/com/runescape/GameWindow.java
+++ b/ElvargClient/src/main/java/com/runescape/GameWindow.java
@@ -60,7 +60,7 @@ public class GameWindow extends JFrame implements ActionListener {
         appletInstance = applet;
         appletInstance.init();
         appletInstance.setMinimumSize(new Dimension(765, 503));
-        appletInstance.setPreferredSize(new Dimension(765, 503));
+        appletInstance.setPreferredSize(((Client) appletInstance).frameDimension());
 
         GridBagConstraints gbc_panel = new GridBagConstraints();
         gbc_panel.fill = GridBagConstraints.BOTH;

--- a/ElvargClient/src/main/java/com/runescape/graphics/sprite/Sprite.java
+++ b/ElvargClient/src/main/java/com/runescape/graphics/sprite/Sprite.java
@@ -19,7 +19,14 @@ import java.awt.image.PixelGrabber;
 import java.awt.image.RGBImageFilter;
 
 public final class Sprite extends Rasterizer2D {
-    
+
+    public static int SETTINGS_FIXED_ACTIVE = 185,
+            SETTINGS_FIXED_INACTIVE = 186,
+            SETTINGS_FIXED_INACTIVE_HOVER = 485,
+            SETTINGS_RESIZABLE_ACTIVE = 484,
+            SETTINGS_RESIZABLE_INACTIVE = 188,
+            SETTINGS_RESIZABLE_INACTIVE_HOVER = 187;
+
     public static Sprite EMPTY_SPRITE = new Sprite();
 
     public int[] myPixels;

--- a/ElvargClient/src/main/java/com/runescape/graphics/widget/SettingsWidget.java
+++ b/ElvargClient/src/main/java/com/runescape/graphics/widget/SettingsWidget.java
@@ -6,6 +6,7 @@ import com.runescape.Client.ScreenMode;
 import com.runescape.graphics.Dropdown;
 import com.runescape.graphics.GameFont;
 import com.runescape.graphics.Slider;
+import com.runescape.graphics.sprite.Sprite;
 import com.runescape.model.content.Keybinding;
 
 public class SettingsWidget extends Widget {
@@ -85,8 +86,13 @@ public class SettingsWidget extends Widget {
 		/* Mouse zoom */
         hoverButton(42521, "Restore Default Zoom", 189, 190);
 		/* Screen sizes */
-        configHoverButton(FIXED_MODE, "Fixed mode", 485, 186, 185, 185, true, RESIZABLE_MODE);
-        configHoverButton(RESIZABLE_MODE, "Resizable mode", 484, 484, 187, 188, false, FIXED_MODE);
+        if (Client.frameMode == ScreenMode.FIXED) {
+            configHoverButton(FIXED_MODE, "Fixed mode", Sprite.SETTINGS_FIXED_ACTIVE, Sprite.SETTINGS_FIXED_ACTIVE, Sprite.SETTINGS_FIXED_INACTIVE_HOVER, Sprite.SETTINGS_FIXED_INACTIVE, true, 42523);
+            configHoverButton(RESIZABLE_MODE, "Resizable mode", Sprite.SETTINGS_RESIZABLE_INACTIVE_HOVER, Sprite.SETTINGS_RESIZABLE_INACTIVE, Sprite.SETTINGS_RESIZABLE_ACTIVE, Sprite.SETTINGS_RESIZABLE_ACTIVE, false, 42522);
+        } else if (Client.frameMode == ScreenMode.RESIZABLE) {
+            configHoverButton(FIXED_MODE, "Fixed mode", Sprite.SETTINGS_FIXED_INACTIVE_HOVER, Sprite.SETTINGS_FIXED_INACTIVE, Sprite.SETTINGS_FIXED_ACTIVE, Sprite.SETTINGS_FIXED_ACTIVE, false, 42523);
+            configHoverButton(RESIZABLE_MODE, "Resizable mode", Sprite.SETTINGS_RESIZABLE_ACTIVE, Sprite.SETTINGS_RESIZABLE_ACTIVE, Sprite.SETTINGS_RESIZABLE_INACTIVE_HOVER, Sprite.SETTINGS_RESIZABLE_INACTIVE, true, 42522);
+        }
 		/* Advanced options */
         hoverButton(42524, "Configure @lre@Advanced options", 353, 353, "Advanced options", Widget.newFonts[1], 0xff981f, 0xffffff, true);
 		/* Sliders */
@@ -233,9 +239,19 @@ public class SettingsWidget extends Widget {
                 switchSettings(button);
                 break;
             case FIXED_MODE:
+                if (Client.frameMode == Client.ScreenMode.FIXED) {
+                    // Prevent flicker if already in fixed
+                    break;
+                }
+
                 Client.instance.frameMode(Client.ScreenMode.FIXED);
                 break;
             case RESIZABLE_MODE:
+                if (Client.frameMode == ScreenMode.RESIZABLE) {
+                    // Prevent flicker if already in resizable
+                    break;
+                }
+
                 Client.instance.frameMode(Client.ScreenMode.RESIZABLE);
                 break;
             case SHIFT_CLICK_DROP:

--- a/ElvargClient/src/main/java/com/runescape/graphics/widget/Widget.java
+++ b/ElvargClient/src/main/java/com/runescape/graphics/widget/Widget.java
@@ -3480,18 +3480,18 @@ public class Widget {
 		tab.active = false;
 	}
 
-	public static void configHoverButton(int id, String tooltip, int enabledSprite, int disabledSprite,
-			int enabledAltSprite, int disabledAltSprite, boolean active, int... buttonsToDisable) {
+	public static void configHoverButton(int id, String tooltip, int initialEnabledSprite, int initialDisabledSprite,
+			int switchedEnabledSprite, int switchedDisabledSprite, boolean active, int... buttonsToDisable) {
 		Widget tab = addInterface(id);
 		tab.tooltip = tooltip;
 		tab.atActionType = OPTION_OK;
 		tab.type = TYPE_CONFIG_HOVER;
-		tab.enabledSprite = Client.spriteCache.lookup(enabledSprite);
-		tab.disabledSprite = Client.spriteCache.lookup(disabledSprite);
+		tab.enabledSprite = Client.spriteCache.lookup(initialEnabledSprite);
+		tab.disabledSprite = Client.spriteCache.lookup(initialDisabledSprite);
 		tab.width = tab.enabledSprite.myWidth;
 		tab.height = tab.disabledSprite.myHeight;
-		tab.enabledAltSprite = Client.spriteCache.lookup(enabledAltSprite);
-		tab.disabledAltSprite = Client.spriteCache.lookup(disabledAltSprite);
+		tab.enabledAltSprite = Client.spriteCache.lookup(switchedEnabledSprite);
+		tab.disabledAltSprite = Client.spriteCache.lookup(switchedDisabledSprite);
 		tab.buttonsToDisable = buttonsToDisable;
 		tab.active = active;
 		tab.spriteOpacity = 255;


### PR DESCRIPTION
-Java client now resizable 800x600 by default (Fixed is painfully tiny on most modern screens)
-Fixed things so we can set default as fixed or resizable with no issues
-Renamed some method parameters to have clearer naming
-Prevented double client window being launched during init()
-Utility function frameDimensions() so we dont have to hardcode 765/503/800/600 all over the client
-Prevented flicker when already in fixed/resizable and clicking activated button

![image](https://user-images.githubusercontent.com/13219416/205481302-47ee775f-0315-43ab-876d-75998b587a9e.png)
