### PR TITLE
Fix for spawning objects above ground level

### DIFF
--- a/ElvargClient/src/main/java/com/runescape/Client.java
+++ b/ElvargClient/src/main/java/com/runescape/Client.java
@@ -13466,16 +13466,16 @@ public class Client extends GameApplet {
             }
         }
         if (packetType == PacketConstants.SEND_OBJECT) {
-            int offset = stream.readUByteA();
-            int x = localX + (offset >> 4 & 7);
-            int y = localY + (offset & 7);
+            int z = stream.readUByteA();
+            int x = localX;
+            int y = localY;
             int id = stream.readLEUShort();
             int objectTypeFace = stream.readUByteS();
             int type = objectTypeFace >> 2;
             int orientation = objectTypeFace & 3;
             int group = objectGroups[type];
             if (x >= 0 && y >= 0 && x < 104 && y < 104) {
-                requestSpawnObject(-1, id, orientation, group, y, type, plane, x, 0);
+                requestSpawnObject(-1, id, orientation, group, y, type, z, x, 0);
             }
             return;
         }


### PR DESCRIPTION
So when spawning an object we send the heightLevel as a uByteA, but this was being interpreted as an offset in the client.

Offset wasn't being used from the server end so I just converted it to interpret as height.

sendPosition doesn't send height level incase you're wondering :)