### PR TITLE
Fix for delayed NPC interaction

### DIFF
--- a/ElvargServer/src/main/java/com/elvarg/game/model/movement/MovementQueue.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/model/movement/MovementQueue.java
@@ -861,7 +861,7 @@ public final class MovementQueue {
                     PathFinder.calculateEntityRoute(player, currentX, currentY);
                 }
 
-                if (runnable != null && player.getMovementQueue().withinEntityInteractionDistance()) {
+                if (runnable != null && player.getMovementQueue().isWithinEntityInteractionDistance()) {
                     // Execute the Runnable now, but continue pathing to the final destination
                     runnable.run();
                 }
@@ -1010,7 +1010,7 @@ public final class MovementQueue {
      * squares away from an NPC but separated by a wall or fence, this will still be accurate.
      * @return
      */
-    private boolean withinEntityInteractionDistance() {
+    private boolean isWithinEntityInteractionDistance() {
         return this.points.size() < NPC_INTERACT_RADIUS && player.getLocation().distanceToPoint(this.pathX, this.pathY) < NPC_INTERACT_RADIUS;
     }
 

--- a/ElvargServer/src/main/java/com/elvarg/game/model/movement/MovementQueue.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/model/movement/MovementQueue.java
@@ -838,7 +838,7 @@ public final class MovementQueue {
 
         final int finalDestinationY = player.getMovementQueue().pathY;
 
-        TaskManager.submit(new Task(1, player.getIndex(), true) {
+        TaskManager.submit(new Task(0, player.getIndex(), true) {
 
             int currentX = entity.getLocation().getX();
 
@@ -856,11 +856,18 @@ public final class MovementQueue {
                     PathFinder.calculateEntityRoute(player, currentX, currentY);
                 }
 
+                boolean withinTwoSqs = player.getLocation().distanceToPoint(finalDestinationX, finalDestinationY) < 3;
+                if (withinTwoSqs) {
+                    player.getPacketSender().sendMessage("Within two sqs, starting interaction");
+                    if (run != null) {
+                        // Execute the Runnable now, but continue pathing to the final destination
+                        run.run();
+                    }
+                }
+
                 if (reachStage != 0) {
                     if (reachStage == 1) {
                         player.getMovementQueue().reset();
-                        if (run != null)
-                            run.run();
                         stop();
                         return;
                     }
@@ -875,9 +882,11 @@ public final class MovementQueue {
                 }
 
                 if (!player.getMovementQueue().hasRoute() || player.getLocation().getX() != finalDestinationX || player.getLocation().getY() != finalDestinationY) {
+                    // Player hasn't got a route or they're not already at destination
                     reachStage = -1;
                     return;
                 }
+
                 reachStage = 1;
                 return;
             }

--- a/ElvargServer/src/main/java/com/elvarg/game/model/movement/MovementQueue.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/model/movement/MovementQueue.java
@@ -857,12 +857,9 @@ public final class MovementQueue {
                 }
 
                 boolean withinTwoSqs = player.getLocation().distanceToPoint(finalDestinationX, finalDestinationY) < 3;
-                if (withinTwoSqs) {
-                    player.getPacketSender().sendMessage("Within two sqs, starting interaction");
-                    if (run != null) {
-                        // Execute the Runnable now, but continue pathing to the final destination
-                        run.run();
-                    }
+                if (withinTwoSqs && run != null) {
+                    // Execute the Runnable now, but continue pathing to the final destination
+                    run.run();
                 }
 
                 if (reachStage != 0) {

--- a/ElvargServer/src/main/java/com/elvarg/game/model/movement/MovementQueue.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/model/movement/MovementQueue.java
@@ -39,9 +39,9 @@ public final class MovementQueue {
     private static final RandomGen RANDOM = new RandomGen();
 
     /**
-     * NPC interactions can begin below this radius of distance.
+     * NPC interactions can begin when the player is within this radius of the NPC.
      */
-    public static final int NPC_INTERACT_RADIUS = 3;
+    public static final int NPC_INTERACT_RADIUS = 2;
 
     /**
      * An enum to represent a Player's Mobility
@@ -1011,7 +1011,7 @@ public final class MovementQueue {
      * @return
      */
     private boolean isWithinEntityInteractionDistance() {
-        return this.points.size() < NPC_INTERACT_RADIUS && player.getLocation().distanceToPoint(this.pathX, this.pathY) < NPC_INTERACT_RADIUS;
+        return this.points.size() <= NPC_INTERACT_RADIUS && player.getLocation().distanceToPoint(this.pathX, this.pathY) <= NPC_INTERACT_RADIUS;
     }
 
 

--- a/ElvargServer/src/main/java/com/elvarg/game/model/movement/MovementQueue.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/model/movement/MovementQueue.java
@@ -39,6 +39,11 @@ public final class MovementQueue {
     private static final RandomGen RANDOM = new RandomGen();
 
     /**
+     * NPC interactions can begin below this radius of distance.
+     */
+    public static final int NPC_INTERACT_RADIUS = 3;
+
+    /**
      * An enum to represent a Player's Mobility
      */
     public enum Mobility {
@@ -812,7 +817,7 @@ public final class MovementQueue {
         this.resetFollow();
     }
 
-    public void walkToEntity(Mobile entity, Runnable run) {
+    public void walkToEntity(Mobile entity, Runnable runnable) {
         int destX = entity.getLocation().getX();
         int destY = entity.getLocation().getY();
 
@@ -856,10 +861,9 @@ public final class MovementQueue {
                     PathFinder.calculateEntityRoute(player, currentX, currentY);
                 }
 
-                boolean withinTwoSqs = player.getLocation().distanceToPoint(finalDestinationX, finalDestinationY) < 3;
-                if (withinTwoSqs && run != null) {
+                if (runnable != null && player.getMovementQueue().withinEntityInteractionDistance()) {
                     // Execute the Runnable now, but continue pathing to the final destination
-                    run.run();
+                    runnable.run();
                 }
 
                 if (reachStage != 0) {
@@ -998,6 +1002,16 @@ public final class MovementQueue {
 
     public boolean isAtDestination() {
         return points.isEmpty();
+    }
+
+    /**
+     * Whether the player is close enough to interact with the given entity.
+     * This also takes into account the player's movement path, so if you're standing 2
+     * squares away from an NPC but separated by a wall or fence, this will still be accurate.
+     * @return
+     */
+    private boolean withinEntityInteractionDistance() {
+        return this.points.size() < NPC_INTERACT_RADIUS && player.getLocation().distanceToPoint(this.pathX, this.pathY) < NPC_INTERACT_RADIUS;
     }
 
 

--- a/ElvargServer/src/main/java/com/elvarg/game/task/Task.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/task/Task.java
@@ -37,6 +37,7 @@ public abstract class Task {
      * A flag which indicates if this task is still running.
      */
     private boolean running = true;
+
     /**
      * The task's owner
      */
@@ -154,7 +155,8 @@ public abstract class Task {
      * @return A flag indicating if the task is running.
      */
     public boolean tick() {
-        if (running && --countdown == 0) {
+        if (running && (countdown == 0 || --countdown == 0)) {
+            // Execute task if there is no delay or the delay has elapsed on this tick
             execute();
             countdown = delay;
         }


### PR DESCRIPTION
- Fixed how our MovementQueue processed walkToEntity
- Made NPC interactions run within 2 sqs of entity (1:1 with OSRS), but keep pathing to final destination
- Fixed a bug where Tasks needed to have a minimum of 1 tick delay (now they can execute on every tick by using 0)

OSRS behaviour:
https://gyazo.com/9e3bec3ac3ddc66b53c946799d979ed1

Before fix:
https://gyazo.com/a2b06b2181bf7a3fdfca4b2685815a25

Fixed:
https://gyazo.com/0ff12232a436c370e6ff8f6a0bb8a647

