### PR TITLE
Fix for special attack resetting when equipping a different weapon

### DIFF
--- a/ElvargServer/src/main/java/com/elvarg/net/packet/impl/EquipPacketListener.java
+++ b/ElvargServer/src/main/java/com/elvarg/net/packet/impl/EquipPacketListener.java
@@ -186,6 +186,9 @@ public class EquipPacketListener implements PacketExecutor {
 				if (equipmentSlot == Equipment.WEAPON_SLOT) {
 					var newWeaponHasSpecial = CombatSpecial.SPECIAL_ATTACK_WEAPON_IDS.contains(id);
 					resetWeapon(player, !newWeaponHasSpecial);
+					//resets special attack when equipping a different weapon
+					player.setSpecialActivated(false);
+					CombatSpecial.updateBar(player);
 				}
 
 				if (player.getEquipment().get(Equipment.WEAPON_SLOT).getId() != 4153) {


### PR DESCRIPTION
fix for special attack resetting when equipping a different weapon