### PR TITLE
Swap magic/defense ratios in effective magic defense level

### DIFF
--- a/ElvargServer/src/main/java/com/elvarg/game/content/Food.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/content/Food.java
@@ -94,16 +94,16 @@ public class Food {
 		
 		if (food == Edible.ANGLERFISH) {
 			int c = 2;
-			if (currentHp >= 25) {
+			if (maxHp >= 25) {
 				c = 4;
 			}
-			if (currentHp >= 50) {
+			if (maxHp >= 50) {
 				c = 6;
 			}
-			if (currentHp >= 75) {
+			if (maxHp >= 75) {
 				c = 8;
 			}
-			if (currentHp >= 93) {
+			if (maxHp >= 93) {
 				c = 13;
 			}
 			healAmount = (int) Math.floor((maxHp / 10) + c);

--- a/ElvargServer/src/main/java/com/elvarg/game/content/Food.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/content/Food.java
@@ -106,7 +106,7 @@ public class Food {
 			if (currentHp >= 93) {
 				c = 13;
 			}
-			healAmount = (int) Math.floor((currentHp/10) + c);
+			healAmount = (int) Math.floor((maxHp / 10) + c);
 			if (healAmount > 22) {
 				healAmount = 22;
 			}

--- a/ElvargServer/src/main/java/com/elvarg/game/content/combat/formula/AccuracyFormulasDpsCalc.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/content/combat/formula/AccuracyFormulasDpsCalc.java
@@ -348,8 +348,8 @@ public class AccuracyFormulasDpsCalc {
             int npcMagicDefence = 0; // always 0 right now
             return (9 + npcMagicLevel) * (npcMagicDefence + 64);
         }
-        int magicLevelPart = (int) Math.floor(effectiveMagicLevel(enemy, true) * 0.3);
-        int defLevelPart = (int) Math.floor(effectiveDefenseLevel(enemy) * 0.7);
+        int magicLevelPart = (int) Math.floor(effectiveMagicLevel(enemy, true) * 0.7);
+        int defLevelPart = (int) Math.floor(effectiveDefenseLevel(enemy) * 0.3);
 
         int defLevel = magicLevelPart + defLevelPart;
         int defBonus = enemy.getAsPlayer().getBonusManager().getDefenceBonus()[BonusManager.DEFENCE_MAGIC];


### PR DESCRIPTION
Accidentally had these swapped in my last PR, this fixes that.

Defense level should be 30%, and magic level should be 70%: https://web.archive.org/web/20190905124128/http://webcache.googleusercontent.com/search?q=cache:http://services.runescape.com/m=forum/forums.ws?317,318,712,65587452

![image](https://user-images.githubusercontent.com/28943608/233218101-6ba7694c-68a9-447d-b1f1-24252a9f8ed9.png)
