### PR TITLE
Tile Stacking

### DIFF
--- a/ElvargServer/src/main/java/com/elvarg/game/collision/Region.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/collision/Region.java
@@ -2,8 +2,12 @@ package com.elvarg.game.collision;
 
 import com.elvarg.game.entity.impl.player.Player;
 import com.elvarg.game.model.Location;
+import com.elvarg.game.model.Tile;
+import com.google.common.collect.Lists;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * Represents a region.
@@ -32,6 +36,10 @@ public class Region {
      */
     public int[][][] clips = new int[4][][];
 
+    public Tile[][][] tiles;
+
+    public List<Tile> activeTiles;
+
     /**
      * Has this region been loaded?
      */
@@ -53,6 +61,7 @@ public class Region {
         this.regionId = regionId;
         this.terrainFile = terrainFile;
         this.objectFile = objectFile;
+        this.activeTiles = Lists.newCopyOnWriteArrayList();
     }
 
     public int getRegionId() {
@@ -84,6 +93,22 @@ public class Region {
             clips[height] = new int[64][64];
         }
         return clips[height][x - regionAbsX][y - regionAbsY];
+    }
+
+    public Tile getTile(int x, int y, int z, boolean create) {
+        int baseX = (regionId >> 8) * 64;
+        int baseY = (regionId & 0xff) * 64;
+        int localX = x - baseX;
+        int localY = y - baseY;
+        if(tiles == null) {
+            if(!create)
+                return null;
+            tiles = new Tile[4][64][64];
+        }
+        Tile tile = tiles[z][localX][localY];
+        if(tile == null && create)
+            tile = tiles[z][localX][localY] = new Tile(this);
+        return tile;
     }
 
     /**
@@ -138,6 +163,18 @@ public class Region {
         int localX = absX - regionAbsX;
         int localY = absY - regionAbsY;
         return new int[]{localX, localY};
+    }
+
+    public static Region get(int regionId) {
+        return RegionManager.regions.get(regionId);
+    }
+
+    public static Region get(int absX, int absY) {
+        return get(getId(absX, absY));
+    }
+
+    public static int getId(int absX, int absY) {
+        return ((absX >> 6) << 8) | absY >> 6;
     }
 
     public boolean isLoaded() {

--- a/ElvargServer/src/main/java/com/elvarg/game/definition/NpcDefinition.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/definition/NpcDefinition.java
@@ -28,7 +28,13 @@ public class NpcDefinition {
      * A fallback set of stats for NPCs.
      */
     private static final int[] DEFAULT_STATS = new int[] { 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-    
+
+    public boolean canTileStack = true;
+
+    public boolean canTileStack() {
+        return canTileStack;
+    }
+
     //VALUES from original Elvarg Definitions
     private int attackAnim;
     private int defenceAnim;

--- a/ElvargServer/src/main/java/com/elvarg/game/entity/impl/Mobile.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/entity/impl/Mobile.java
@@ -42,6 +42,8 @@ public abstract class Mobile extends Entity {
 	private Graphic graphic;
 	private Mobile following;
 
+	public boolean occupyingTiles;
+
 	private Map<Object, Object> attributes = Maps.newConcurrentMap();
 
 	public Object getAttribute(Object name) {
@@ -86,6 +88,10 @@ public abstract class Mobile extends Entity {
 	 */
 	private boolean registered;
 
+	public Player player;
+
+	public NPC npc;
+
 	/**
 	 * Constructs this character/entity
 	 *
@@ -93,6 +99,13 @@ public abstract class Mobile extends Entity {
 	 */
 	public Mobile(Location position) {
 		super(position);
+		if (this instanceof Player) {
+			player = (Player) this;
+			npc = null;
+		} else {
+			npc = (NPC) this;
+			player = null;
+		}
 	}
 
 	/**

--- a/ElvargServer/src/main/java/com/elvarg/game/entity/impl/npc/NPC.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/entity/impl/npc/NPC.java
@@ -20,6 +20,7 @@ import com.elvarg.game.entity.impl.player.Player;
 import com.elvarg.game.model.Direction;
 import com.elvarg.game.model.Ids;
 import com.elvarg.game.model.Location;
+import com.elvarg.game.model.Tile;
 import com.elvarg.game.model.areas.AreaManager;
 import com.elvarg.game.model.areas.impl.WildernessArea;
 import com.elvarg.game.task.TaskManager;
@@ -154,6 +155,15 @@ public class NPC extends Mobile {
 		} else {
 			setHitpoints(getDefinition().getHitpoints());
 		}
+		Tile.occupy(this);
+	}
+
+	public void setTileStacking(boolean tileStack) {
+		if (this.getDefinition() == null) {
+			System.err.println("This NPC doesn't have definitions to set for tile stacking.");
+			return;
+		}
+		this.getDefinition().canTileStack = tileStack;
 	}
 
 	@Override

--- a/ElvargServer/src/main/java/com/elvarg/game/entity/impl/player/Player.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/entity/impl/player/Player.java
@@ -43,24 +43,7 @@ import com.elvarg.game.entity.impl.Mobile;
 import com.elvarg.game.entity.impl.npc.NPC;
 import com.elvarg.game.entity.impl.npc.NpcAggression;
 import com.elvarg.game.entity.impl.playerbot.PlayerBot;
-import com.elvarg.game.model.Animation;
-import com.elvarg.game.model.Appearance;
-import com.elvarg.game.model.ChatMessage;
-import com.elvarg.game.model.EffectTimer;
-import com.elvarg.game.model.EnteredAmountAction;
-import com.elvarg.game.model.EnteredSyntaxAction;
-import com.elvarg.game.model.Flag;
-import com.elvarg.game.model.ForceMovement;
-import com.elvarg.game.model.God;
-import com.elvarg.game.model.Item;
-import com.elvarg.game.model.Location;
-import com.elvarg.game.model.MagicSpellbook;
-import com.elvarg.game.model.PlayerInteractingOption;
-import com.elvarg.game.model.PlayerRelations;
-import com.elvarg.game.model.PlayerStatus;
-import com.elvarg.game.model.SecondsTimer;
-import com.elvarg.game.model.Skill;
-import com.elvarg.game.model.SkullType;
+import com.elvarg.game.model.*;
 import com.elvarg.game.model.areas.AreaManager;
 import com.elvarg.game.model.container.impl.Bank;
 import com.elvarg.game.model.container.impl.Equipment;
@@ -687,6 +670,7 @@ public class Player extends Mobile {
 
 			System.out.println(GameConstants.PLAYER_BOTS.length + " player bots now online.");
 		}
+		Tile.occupy(this);
 	}
 
 	/**

--- a/ElvargServer/src/main/java/com/elvarg/game/model/Tile.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/model/Tile.java
@@ -1,0 +1,74 @@
+package com.elvarg.game.model;
+
+import com.elvarg.game.collision.Region;
+import com.elvarg.game.entity.impl.Mobile;
+
+/**
+ * @author Ynneh | 29/04/2023 - 10:56 am
+ * <https://github.com/drhenny>
+ *
+ * Only used for TileStacking NPCs
+ */
+public class Tile {
+
+    public final Region region;
+    public int playerCount, npcCount;
+    public Tile(Region region) {
+        this.region = region;
+    }
+
+    public static void occupy(Mobile entity) {
+        if (entity.occupyingTiles) {
+            fill(entity, entity.getLocation(), -1);
+            entity.occupyingTiles = false;
+        }
+        if (entity.npc != null && !entity.npc.getDefinition().canTileStack())
+            return;
+        fill(entity, entity.getLocation(), 1);
+        entity.occupyingTiles = true;
+    }
+
+    public static boolean isOccupied(Mobile entity, int stepX, int stepY) {
+        Location position = entity.getLocation();
+        int size = entity.size();
+        int absX = position.getX();
+        int absY = position.getY();
+        int z = position.getZ();
+        int eastMostX = absX + (size - 1);
+        int northMostY = absY + (size - 1);
+        for(int x = stepX; x < (stepX + size); x++) {
+            for(int y = stepY; y < (stepY + size); y++) {
+                if(x >= absX && x <= eastMostX && y >= absY && y <= northMostY) {
+                    /* stepping within itself, allow it */
+                    continue;
+                }
+                Tile tile = Tile.get(x, y, z, true);
+                if(tile.playerCount > 0 || tile.npcCount > 0)
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    private static void fill(Mobile entity, Location pos, int increment) {
+        int size = entity.size();
+        int absX = pos.getX();
+        int absY = pos.getY();
+        int z = pos.getZ();
+        for(int x = absX; x < (absX + size); x++) {
+            for(int y = absY; y < (absY + size); y++) {
+                Tile tile = Tile.get(x, y, z, true);
+                if(entity.player != null)
+                    tile.playerCount += increment;
+                else
+                    tile.npcCount += increment;
+            }
+        }
+    }
+
+    public static Tile get(int x, int y, int z, boolean create) {
+        return Region.get(x, y).getTile(x, y, z, create);
+    }
+
+
+}

--- a/ElvargServer/src/main/java/com/elvarg/game/model/movement/MovementQueue.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/model/movement/MovementQueue.java
@@ -16,6 +16,7 @@ import com.elvarg.game.entity.impl.player.Player;
 import com.elvarg.game.model.Direction;
 import com.elvarg.game.model.Location;
 import com.elvarg.game.model.Skill;
+import com.elvarg.game.model.Tile;
 import com.elvarg.game.model.movement.path.PathFinder;
 import com.elvarg.game.model.movement.path.RS317PathFinder;
 import com.elvarg.game.model.rights.PlayerRights;
@@ -213,6 +214,14 @@ public final class MovementQueue {
             return;
         }
 
+        if(this.character.isNpc()) {
+            NPC npc = this.character.getAsNpc();
+            if (npc.getDefinition().canTileStack() && Tile.isOccupied(npc, x, y)) {
+                reset();
+                return;
+            }
+        }
+
         if (points.size() >= MAXIMUM_SIZE)
             return;
 
@@ -241,6 +250,7 @@ public final class MovementQueue {
         int deltaX = x - last.position.getX();
         int deltaY = y - last.position.getY();
         final int max = Math.max(Math.abs(deltaX), Math.abs(deltaY));
+
         for (int i = 0; i < max; i++) {
             if (deltaX < 0)
                 deltaX++;
@@ -407,6 +417,7 @@ public final class MovementQueue {
         }
 
         isMoving = moved;
+        Tile.occupy(character);
     }
 
     public boolean canWalkTo(Location next) {


### PR DESCRIPTION
Added tile stacking for NPCs. 

When an NPC is trying to move to the next tile via pathfinder IF they can tilestack (npc def method) then they will stay behind the NPC infront. This works for all NPCs currently. However, you can override the boolean on spawn by using npc.setTileStacking(ARG);
(false for them NOT to tile stack and true for them to follow the rule)