### PR TITLE
Adjust food combat delay handling

### DIFF
--- a/ElvargServer/src/main/java/com/elvarg/game/content/Food.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/content/Food.java
@@ -65,11 +65,22 @@ public class Food {
 		}
 
 		player.getTimers().extendOrRegister(TimerKey.FOOD, 3);
-		player.getTimers().extendOrRegister(TimerKey.COMBAT_ATTACK, 5);
 
+		final int combatTicks = player.getTimers().getUncappedTicks(TimerKey.COMBAT_ATTACK, Integer.MIN_VALUE);
+		final int addAttackDelay;
 		if (food == Edible.KARAMBWAN) {
-			player.getTimers().register(TimerKey.KARAMBWAN, 2); // Register karambwan timer too
+			player.getTimers().register(TimerKey.KARAMBWAN, 3); // Register karambwan timer too
 			player.getTimers().register(TimerKey.POTION, 3); // Register the potion timer (karambwan blocks pots)
+			addAttackDelay = 2;
+		}
+		else {
+			addAttackDelay = 3;
+		}
+
+		// Attack delays are special in that the 'timer' can go negative, and the delay is added to the timer
+		final int combatTicksAfterEat = combatTicks + addAttackDelay;
+		if (combatTicksAfterEat > 0) {
+			player.getTimers().register(TimerKey.COMBAT_ATTACK, combatTicksAfterEat);
 		}
 
 		// Close interfaces..

--- a/ElvargServer/src/main/java/com/elvarg/util/timers/Timer.java
+++ b/ElvargServer/src/main/java/com/elvarg/util/timers/Timer.java
@@ -7,14 +7,20 @@ public class Timer {
 
 	private TimerKey key;
 	private int ticks;
+	private int uncappedTicks;
 
 	public Timer(TimerKey key, int ticks) {
 		this.key = key;
 		this.ticks = ticks;
+		this.uncappedTicks = ticks;
 	}
 
 	public int ticks() {
 		return ticks;
+	}
+
+	public int uncappedTicks() {
+		return uncappedTicks;
 	}
 
 	public TimerKey key() {
@@ -22,6 +28,7 @@ public class Timer {
 	}
 
 	public void tick() {
+		uncappedTicks--;
 		if (ticks > 0)
 			ticks--;
 	}

--- a/ElvargServer/src/main/java/com/elvarg/util/timers/TimerRepository.java
+++ b/ElvargServer/src/main/java/com/elvarg/util/timers/TimerRepository.java
@@ -41,6 +41,14 @@ public class TimerRepository {
 		return timer.ticks();
 	}
 
+	public int getUncappedTicks(TimerKey key, int defaultValue) {
+		Timer timer = timers.get(key);
+		if (timer == null) {
+			return defaultValue;
+		}
+		return timer.uncappedTicks();
+	}
+
 	public void register(TimerKey key, int ticks) {
 		timers.put(key, new Timer(key, ticks));
 	}


### PR DESCRIPTION
This adjusts combat food delays to be like it is in RS. I'm still doing some testing, but this seems to be right.

Also changes karambwan timer to 3 (karambwans have an eat delay of 3, not 2).

References:
https://oldschool.runescape.wiki/w/Food
https://www.reddit.com/r/2007scape/comments/wtylc4/how_tobasics_of_combo_eating/
![image](https://github.com/RSPSApp/elvarg-rsps/assets/28943608/c9a31a8c-bf0a-4f13-82df-c3915939ad0a)
