### PR TITLE
Improve bolt effects, add zaryte crossbow

### DIFF
--- a/ElvargServer/src/main/java/com/elvarg/game/content/combat/CombatFactory.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/content/combat/CombatFactory.java
@@ -5,7 +5,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
-import com.elvarg.game.content.minigames.impl.pestcontrol.PestControl;
 import com.elvarg.game.content.sound.Sound;
 import com.elvarg.game.content.sound.SoundManager;
 import com.elvarg.game.collision.RegionManager;
@@ -187,12 +186,6 @@ public class CombatFactory {
 						damage = 48;
 					}
 				}
-
-				// Handle bolt special effects for a player whose using crossbow
-				if (player.getWeapon() == WeaponInterface.CROSSBOW && Misc.getRandom(10) == 1) {
-					double multiplier = RangedData.getSpecialEffectsMultiplier(player, victim, damage);
-					damage *= multiplier;
-				}
 			}
 		} else if (type == CombatType.MAGIC) {
 			damage = Misc.inclusive(0, DamageFormulas.getMagicMaxhit(entity));
@@ -217,6 +210,20 @@ public class CombatFactory {
 
 		// Return our hitDamage that may have been modified slightly.
 		return hitDamage;
+	}
+
+	public static void applyExtraHitRolls(Mobile attacker, Mobile target, CombatType combatType, HitDamage damage,
+	                                     boolean accurate, CombatMethod combatMethod) {
+		if (combatType == CombatType.RANGED) {
+			// Handle bolt special effects for a player whose using crossbow
+			if (attacker.isPlayer() && attacker.getAsPlayer().getWeapon() == WeaponInterface.CROSSBOW) {
+				final int updatedDamage = RangedData.applySpecialEffects(attacker.getAsPlayer(), target,
+				                                                         damage.getDamage(), accurate, combatMethod);
+				if (updatedDamage != damage.getDamage()) {
+					damage.setDamage(updatedDamage);
+				}
+			}
+		}
 	}
 
 	/**

--- a/ElvargServer/src/main/java/com/elvarg/game/content/combat/CombatSpecial.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/content/combat/CombatSpecial.java
@@ -30,6 +30,7 @@ import com.elvarg.game.content.combat.method.impl.specials.SaradominGodswordComb
 import com.elvarg.game.content.combat.method.impl.specials.SaradominSwordCombatMethod;
 import com.elvarg.game.content.combat.method.impl.specials.ShoveCombatMethod;
 import com.elvarg.game.content.combat.method.impl.specials.ZamorakGodswordCombatMethod;
+import com.elvarg.game.content.combat.method.impl.specials.ZaryteCrossbowCombatMethod;
 import com.elvarg.game.entity.impl.Mobile;
 import com.elvarg.game.entity.impl.player.Player;
 import com.elvarg.game.model.container.impl.Equipment;
@@ -99,6 +100,8 @@ public enum CombatSpecial {
             WeaponInterface.DARK_BOW),
     ARMADYL_CROSSBOW(new int[]{11785}, 40, 1, 2.0,
             new ArmadylCrossbowCombatMethod(), WeaponInterface.CROSSBOW),
+    ZARYTE_CROSSBOW(new int[]{26374}, 75, 1, 2.0,
+                    new ZaryteCrossbowCombatMethod(), WeaponInterface.CROSSBOW),
     BALLISTA(new int[]{19481},
             65, 1.25, 1.45, new BallistaCombatMethod(), WeaponInterface.BALLISTA),
     ;

--- a/ElvargServer/src/main/java/com/elvarg/game/content/combat/hit/PendingHit.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/content/combat/hit/PendingHit.java
@@ -22,15 +22,15 @@ public class PendingHit {
     public PendingHit(Mobile attacker, Mobile target, CombatMethod method) {
         this(attacker, target, method, true, 0);
     }
-    
+
     public PendingHit(Mobile attacker, Mobile target, CombatMethod method, int delay) {
         this(attacker, target, method, true, delay);
     }
-    
+
     public PendingHit(Mobile attacker, Mobile target, CombatMethod method, boolean rollAccuracy, int delay) {
     	this(attacker, target, method, rollAccuracy, 1, delay);
     }
-    
+
     public PendingHit(Mobile attacker, Mobile target, CombatMethod method, boolean rollAccuracy, int hitAmount, int delay) {
         this.attacker = attacker;
         this.target = target;
@@ -45,20 +45,20 @@ public class PendingHit {
         this.attacker = attacker;
         this.target = target;
         this.method = method;
-        this.combatType = method.type();   	
+        this.combatType = method.type();
     }
-    
+
     /**
      * New method added to allow the adding of pending damage of a pre-determined value at a specific delay.
      * @param attacker Attacking mobile entity.
      * @param target Recipient mobile entity of the damage.
      * @param method The combat method used.
      * @param damage The calculated damage amount.
-     * @param delay 
+     * @param delay
      */
     public static PendingHit create(Mobile attacker, Mobile target, CombatMethod method, int damage, boolean accurate) {
     	PendingHit hit = new PendingHit(method, attacker, target);
-    	
+
     	hit.hits = new HitDamage[] {new HitDamage(damage, damage == 0 ? HitMask.BLUE : HitMask.RED)};
         hit.delay = 0; //The delay before the hit (0 in most cases with current combat system design).
         hit.handleAfterHitEffects = true;
@@ -66,7 +66,7 @@ public class PendingHit {
     	hit.totalDamage += damage;
     	return hit;
     }
-        
+
     public Mobile getAttacker() {
         return attacker;
     }
@@ -133,6 +133,7 @@ public class PendingHit {
         for (int i = 0; i < hits.length; i++) {
             accurate = !rollAccuracy || AccuracyFormulasDpsCalc.rollAccuracy(attacker, target, combatType);
             HitDamage damage = accurate ? CombatFactory.getHitDamage(attacker, target, combatType) : new HitDamage(0, HitMask.BLUE);
+            CombatFactory.applyExtraHitRolls(attacker, target, combatType, damage, accurate, method);
             totalDamage += damage.getDamage();
             hits[i] = damage;
         }

--- a/ElvargServer/src/main/java/com/elvarg/game/content/combat/method/impl/specials/ZaryteCrossbowCombatMethod.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/content/combat/method/impl/specials/ZaryteCrossbowCombatMethod.java
@@ -1,0 +1,45 @@
+package com.elvarg.game.content.combat.method.impl.specials;
+
+import com.elvarg.game.content.combat.CombatFactory;
+import com.elvarg.game.content.combat.CombatSpecial;
+import com.elvarg.game.content.combat.hit.PendingHit;
+import com.elvarg.game.content.combat.method.impl.RangedCombatMethod;
+import com.elvarg.game.content.combat.ranged.RangedData.RangedWeapon;
+import com.elvarg.game.entity.impl.Mobile;
+import com.elvarg.game.entity.impl.player.Player;
+import com.elvarg.game.model.Animation;
+import com.elvarg.game.model.Priority;
+import com.elvarg.game.model.Projectile;
+
+public class ZaryteCrossbowCombatMethod extends RangedCombatMethod {
+
+    private static final Animation ANIMATION = new Animation(9166, Priority.HIGH);
+    private static final Projectile PROJECTILE = new Projectile(301, 44, 35, 50, 70);
+
+    @Override
+    public PendingHit[] hits(Mobile character, Mobile target) {
+        return new PendingHit[] { new PendingHit(character, target, this, 2) };
+    }
+
+    @Override
+    public boolean canAttack(Mobile character, Mobile target) {
+        Player player = character.getAsPlayer();
+        if (player.getCombat().getRangedWeapon() != RangedWeapon.ZARYTE_CROSSBOW) {
+            return false;
+        }
+        if (!CombatFactory.checkAmmo(player, 1)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void start(Mobile character, Mobile target) {
+        final Player player = character.getAsPlayer();
+        CombatSpecial.drain(player, CombatSpecial.ZARYTE_CROSSBOW.getDrainAmount());
+        player.performAnimation(ANIMATION);
+        Projectile.sendProjectile(character, target, PROJECTILE);
+        CombatFactory.decrementAmmo(player, target.getLocation(), 1);
+        // This also does a guaranteed enchanted bolt hit, see CombatFactory.applyExtraHitRolls()
+    }
+}


### PR DESCRIPTION
This makes bolt effects much more accurate to how they actually are (the effects, and the probability of them activating). It's mostly accurate now.

Some things are more effort than it's worth to change with how the combat system works right now, so I didn't change those. For example, diamond bolt e will guarantee an accurate hit so those need to be processed before the hit, whereas most bolt effects go after, but hhere everything happens at the end of a tick.

This also adds support for zaryte crossbow, including special attack.

All bolt effects taken from the wiki