### PR TITLE
Fix DH damage modifier calculation, and fix healing when current health > max

### DIFF
--- a/ElvargServer/src/main/java/com/elvarg/game/content/combat/formula/DamageFormulas.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/content/combat/formula/DamageFormulas.java
@@ -72,8 +72,7 @@ public class DamageFormulas {
         if (CombatFactory.fullDharoks(player)) {
             float hp = player.getHitpoints();
             float max = player.getSkillManager().getMaxLevel(Skill.HITPOINTS);
-            float mult = Math.max(0, ((max - hp) / max) * 100f) + 100f;
-            maxHit *= (mult / 100);
+            maxHit *= 1 + ((max - hp) / 100f) * (max / 100f);
         }
 
         if (player.isSpecialActivated()) {

--- a/ElvargServer/src/main/java/com/elvarg/game/entity/impl/player/Player.java
+++ b/ElvargServer/src/main/java/com/elvarg/game/entity/impl/player/Player.java
@@ -326,12 +326,10 @@ public class Player extends Mobile {
 
 	@Override
 	public void heal(int amount) {
-		int level = skillManager.getMaxLevel(Skill.HITPOINTS);
-		if ((skillManager.getCurrentLevel(Skill.HITPOINTS) + amount) >= level) {
-			setHitpoints(level);
-		} else {
-			setHitpoints(skillManager.getCurrentLevel(Skill.HITPOINTS) + amount);
-		}
+		final int cap = Math.max(skillManager.getMaxLevel(Skill.HITPOINTS),
+		                         skillManager.getCurrentLevel(Skill.HITPOINTS));
+		final int healedHp = skillManager.getCurrentLevel(Skill.HITPOINTS) + amount;
+		setHitpoints(Math.min(healedHp, cap));
 	}
 
 	@Override


### PR DESCRIPTION
This fixes two separate issues:
* One minor issue where the DH formula was slightly inaccurate, mostly noticeable if max hp was not 99, see https://oldschool.runescape.wiki/w/Dharok_the_Wretched%27s_equipment
* Issue when healing with current hp > max hp, for example, eat an anglerfish so HP is above 99, then cast blood barrage, HP will be reset to 99 currently