### PR TITLE
Fix bankers that don't open the bank (closes #243, #245)

### DIFF
--- a/ElvargServer/game/src/main/java/com/elvarg/game/entity/impl/npc/impl/Banker.java
+++ b/ElvargServer/game/src/main/java/com/elvarg/game/entity/impl/npc/impl/Banker.java
@@ -2,10 +2,21 @@ package com.elvarg.game.entity.impl.npc.impl;
 
 import com.elvarg.game.entity.impl.npc.NPC;
 import com.elvarg.game.entity.impl.player.Player;
+import com.elvarg.game.model.Ids;
 import com.elvarg.game.model.Location;
 import com.elvarg.game.model.dialogues.builders.impl.BankerDialogue;
 import com.elvarg.game.entity.impl.npc.NPCInteraction;
 
+import static com.elvarg.util.NpcIdentifiers.*;
+
+@Ids({BANKER, BANKER_2, BANKER_3, BANKER_4, BANKER_5, BANKER_6, BANKER_7, BANKER_8,
+        BANKER_9, BANKER_10, BANKER_11, BANKER_12, BANKER_13, BANKER_14, BANKER_15,
+        BANKER_16, BANKER_17, BANKER_18, BANKER_19, BANKER_20, BANKER_21, BANKER_22,
+        BANKER_23, BANKER_24, BANKER_25, BANKER_26, BANKER_27, BANKER_28, BANKER_29,
+        BANKER_30, BANKER_31, BANKER_32, BANKER_33, BANKER_34, BANKER_35, BANKER_36,
+        BANKER_37, BANKER_38, BANKER_39, BANKER_40, BANKER_41, BANKER_42, BANKER_43,
+        BANKER_44, BANKER_45, BANKER_46, BANKER_47, BANKER_48, BANKER_49, BANKER_50,
+        BANKER_51, BANKER_TUTOR, GHOST_BANKER, SIRSAL_BANKER, NARDAH_BANKER, GNOME_BANKER})
 public class Banker extends NPC implements NPCInteraction {
 
     /**

--- a/ElvargServer/game/src/main/java/com/elvarg/net/packet/impl/NPCOptionPacketListener.java
+++ b/ElvargServer/game/src/main/java/com/elvarg/net/packet/impl/NPCOptionPacketListener.java
@@ -130,7 +130,6 @@ public class NPCOptionPacketListener extends NpcIdentifiers implements PacketExe
                 case ARMOUR_SALESMAN:
                     ShopManager.open(player, ShopIdentifiers.RANGE_SHOP);
                     break;
-                case BANKER_2:
                 case TZHAAR_KET_ZUH:
                     player.getBank(player.getCurrentBankTab()).open();
                     break;
@@ -183,13 +182,6 @@ public class NPCOptionPacketListener extends NpcIdentifiers implements PacketExe
                 case NIEVE:
                     player.getDialogueManager().start(new NieveDialogue(), 2);
                     break;
-                case BANKER:
-                case BANKER_2:
-                case BANKER_3:
-                case BANKER_4:
-                case BANKER_5:
-                case BANKER_6:
-                case BANKER_7:
                 case TZHAAR_KET_ZUH:
                     player.getBank(player.getCurrentBankTab()).open();
                     break;


### PR DESCRIPTION
Fixes #243 and #245.

**Root cause:** `Banker.java` implements `NPCInteraction` but was missing the `@Ids` annotation, so it was never registered in `NPC_IMPLEMENTATION_MAP` — banker NPCs spawned as plain `NPC` and clicks fell through to the packet-listener switch, which only covered ids 394–400. Every other banker (Falador, Al Kharid, etc.) did nothing when clicked.

**Fix:**
- Added `@Ids({...})` to `Banker.java` covering all banker NPC ids (`BANKER`–`BANKER_51`, plus `BANKER_TUTOR`, `GHOST_BANKER`, `SIRSAL_BANKER`, `NARDAH_BANKER`, `GNOME_BANKER`). Talk-to starts the banker dialogue, Bank opens the bank — same behavior the handful of working bankers already had.
- Removed the now-dead `BANKER*` cases from `NPCOptionPacketListener` (the interaction system runs before the switch, so those cases could never be reached). `TZHAAR_KET_ZUH` handling is unchanged.

Verified with `gradlew :game:compileJava`.